### PR TITLE
add spec file for RPM package support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 info
 doxygen
+*.o
+*.rpm
+mouse_m908

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Control Redragon gaming mice from Linux, BSD and Haiku
 	- [Safety](#safety)
 - [Installing](#installing)
 	- [Linux](#linux)
+       - [Fedora/RHEL](#fedora)
 	- [OpenBSD and FreeBSD](#openbsd-and-freebsd)
 	- [Haiku](#haiku)
 	- [Other platforms](#other-platforms)
@@ -68,6 +69,22 @@ As the question of safety has been asked before and there is no simple answer, i
 
 
 ## Installing
+
+### Fedora/RHEL
+
+RPM Package support was added so you can install `mouse_m908` via your package manager.
+
+- Clone this repo
+- Install build dependencies: `dnf builddep mouse_m908.spec`
+- run:
+```
+make
+make rpm
+```
+- Install the resulting package by running:
+```
+sudo dnf install ./mouse_m908-3.1-1.x86_64.rpm
+```
 
 ### Linux
 - Install the dependencies:

--- a/makefile
+++ b/makefile
@@ -37,7 +37,7 @@ install-bsd:
 
 # remove binary
 clean:
-	rm mouse_m908 *.o
+	rm mouse_m908 *.o mouse_m908*.rpm
 	rm -r Haiku/bin Haiku/documentation Haiku/mouse_m908.hpkg | true
 
 # remove all installed files
@@ -49,6 +49,14 @@ uninstall:
 
 # this is an alias to install for backwards compatibility
 upgrade: install
+
+# this builds a .rpm for Fedora/RHEL systems
+rpm:
+	rpmbuild --buildroot $(PWD)/rpmbuild/BUILDROOT --define "_topdir $(PWD)/rpmbuild" -bb mouse_m908.spec
+
+# this builds .src.rpm for Fedora/RHEL systems
+src-rpm:
+	rpmbuild --buildroot $(PWD)/rpmbuild/BUILDROOT --define "_topdir $(PWD)/rpmbuild" -bs mouse_m908.spec
 
 # this builds a .hpkg package on Haiku
 hpkg:

--- a/mouse_m908.spec
+++ b/mouse_m908.spec
@@ -1,0 +1,54 @@
+# Don't put rpm package in subdir see: https://stackoverflow.com/questions/2565509/rpmbuild-generates-rpm-in-which-subdirectory
+%define _build_name_fmt %{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}.rpm
+# Drop the RPM in PWD
+%define _rpmdir %{getenv:PWD}
+%define _srcrpmdir %{getenv:PWD}
+%define _sourcedir %{getenv:PWD}
+
+Name: mouse_m908
+Version: 3.1
+Release: 1
+Summary: Control Redragon gaming mice from Linux, BSD and Haiku
+
+License: GPL v3
+URL:     https://github.com/dokutan/mouse_m908
+BuildRequires: gcc-c++ libusb libusb-devel
+Requires: libusb
+ExclusiveArch: x86_64
+
+%description
+Control Redragon gaming mice from Linux, BSD and Haiku
+
+%build
+make -C %{_sourcedir}
+
+%install
+mkdir -p %{buildroot}%{_bindir}
+mkdir -p %{buildroot}%{_docdir}
+mkdir -p %{buildroot}%{_mandir}/man1
+mkdir -p %{buildroot}%{_sysconfdir}/udev/rules.d
+
+make -C %{_sourcedir}\
+     PREFIX=%{buildroot} \
+     BIN_DIR=%{buildroot}/%{_bindir} \
+     ETC_DIR=%{buildroot}/etc \
+     DOC_DIR=%{buildroot}%{_docdir} \
+     MAN_DIR=%{buildroot}%{_mandir}/man1 install
+
+%clean
+rm -rf %{buildroot}
+
+%pre
+
+%post
+
+%files
+%{_bindir}/%{name}
+%{_docdir}/%{name}
+%{_mandir}/man1/%{name}.1.gz
+%{_sysconfdir}/udev/rules.d/%{name}.rules
+
+%changelog
+* Sat Feb 06 2021 Alex - 3.1-1
+- first RPM release
+


### PR DESCRIPTION
A couple make targets were added `make rpm` and `make src-rpm`.
These build an RPM package and a src rpm package.

see the readme on how to build the package, you can try this on a container by doing:

```
docker run -it fedora:latest
$ git clone https://github.com/akdev1l/mouse_m908.git
$ cd mouse_m908
$ dnf builddep mouse_m908.spec
$ make -j15
$ make rpm
$ dnf install ./mouse_m908-3.1-1.x86_64.rpm
$ mouse_m908 --help
```