### PR TITLE
Add cmake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2021 George Florea Bănuș <georgefb899@gmail.com>
 #
-# SPDX-License-Identifier: GPL-3.0-only
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 cmake_minimum_required(VERSION 3.15)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: 2021 George Florea Bănuș <georgefb899@gmail.com>
+#
+# SPDX-License-Identifier: GPL-3.0-only
+
+cmake_minimum_required(VERSION 3.15)
+
+project(mouse_m908 LANGUAGES CXX)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
+include(GNUInstallDirs)
+include(FeatureSummary)
+
+find_package(LibUSB)
+set_package_properties(LibUSB PROPERTIES TYPE REQUIRED)
+
+feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)
+
+add_executable(mouse_m908)
+target_sources(mouse_m908
+    PRIVATE
+        mouse_m908.cpp
+        include/data.cpp
+        include/help.h
+        include/load_config.cpp
+        include/load_config.h
+        include/rd_mouse.cpp
+        include/rd_mouse.h
+        include/generic/constructor.cpp
+        include/generic/data.cpp
+        include/generic/getters.cpp
+        include/generic/helpers.cpp
+        include/generic/mouse_generic.h
+        include/generic/readers.cpp
+        include/generic/setters.cpp
+        include/generic/writers.cpp
+        include/m709/constructor.cpp
+        include/m709/data.cpp
+        include/m709/getters.cpp
+        include/m709/helpers.cpp
+        include/m709/mouse_m709.h
+        include/m709/readers.cpp
+        include/m709/setters.cpp
+        include/m709/writers.cpp
+        include/m711/constructor.cpp
+        include/m711/data.cpp
+        include/m711/getters.cpp
+        include/m711/helpers.cpp
+        include/m711/mouse_m711.h
+        include/m711/readers.cpp
+        include/m711/setters.cpp
+        include/m711/writers.cpp
+        include/m715/constructor.cpp
+        include/m715/data.cpp
+        include/m715/getters.cpp
+        include/m715/helpers.cpp
+        include/m715/mouse_m715.h
+        include/m715/readers.cpp
+        include/m715/setters.cpp
+        include/m715/writers.cpp
+        include/m908/constructor.cpp
+        include/m908/data.cpp
+        include/m908/getters.cpp
+        include/m908/helpers.cpp
+        include/m908/mouse_m908.h
+        include/m908/readers.cpp
+        include/m908/setters.cpp
+        include/m908/writers.cpp
+        include/m990/constructor.cpp
+        include/m990/data.cpp
+        include/m990/getters.cpp
+        include/m990/helpers.cpp
+        include/m990/mouse_m990.h
+        include/m990/readers.cpp
+        include/m990/setters.cpp
+        include/m990/writers.cpp
+        include/m990chroma/constructor.cpp
+        include/m990chroma/data.cpp
+        include/m990chroma/getters.cpp
+        include/m990chroma/helpers.cpp
+        include/m990chroma/mouse_m990chroma.h
+        include/m990chroma/readers.cpp
+        include/m990chroma/setters.cpp
+        include/m990chroma/writers.cpp
+)
+
+target_link_libraries(mouse_m908 PRIVATE LibUSB::LibUSB)
+
+install(TARGETS mouse_m908 DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(FILES mouse_m908.rules DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/udev/rules.d)
+install(FILES mouse_m908.1 DESTINATION ${CMAKE_INSTALL_MANDIR})
+install(FILES README.md DESTINATION ${CMAKE_INSTALL_DOCDIR})
+install(FILES keymap.md DESTINATION ${CMAKE_INSTALL_DOCDIR})
+install(DIRECTORY examples DESTINATION ${CMAKE_INSTALL_DOCDIR})

--- a/cmake/FindLibUSB.cmake
+++ b/cmake/FindLibUSB.cmake
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2006 Laurent Montel <montel@kde.org>
+# SPDX-FileCopyrightText: 2019 Heiko Becker <heirecka@exherbo.org>
+# SPDX-FileCopyrightText: 2020 Elvis Angelaccio <elvis.angelaccio@kde.org>
+# SPDX-FileCopyrightText: 2021 George Florea Bănuș <georgefb899@gmail.com>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+find_package(PkgConfig QUIET)
+
+pkg_check_modules(PC_USB QUIET libusb-1.0)
+
+find_path(LibUSB_INCLUDE_DIRS
+    NAMES libusb.h
+    PATH_SUFFIXES libusb-1.0
+    HINTS ${PC_USB_INCLUDEDIR}
+)
+
+find_library(LibUSB_LIBRARIES
+    NAMES usb-1.0
+    HINTS ${PC_USB_LIBDIR}
+)
+
+set(LibUSB_VERSION ${PC_USB_VERSION})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LibUSB
+    FOUND_VAR
+        LibUSB_FOUND
+    REQUIRED_VARS
+        LibUSB_LIBRARIES
+        LibUSB_INCLUDE_DIRS
+    VERSION_VAR
+        LibUSB_VERSION
+)
+
+if (LibUSB_FOUND AND NOT TARGET LibUSB::LibUSB)
+    add_library(LibUSB::LibUSB UNKNOWN IMPORTED)
+    set_target_properties(LibUSB::LibUSB PROPERTIES
+        IMPORTED_LOCATION "${LibUSB_LIBRARIES}"
+        INTERFACE_INCLUDE_DIRECTORIES "${LibUSB_INCLUDE_DIRS}"
+    )
+endif()
+
+mark_as_advanced(LibUSB_LIBRARIES LibUSB_INCLUDE_DIRS)
+
+include(FeatureSummary)
+set_package_properties(LibUSB PROPERTIES
+    URL "https://libusb.info"
+    DESCRIPTION "a C library that provides generic access to USB devices."
+)


### PR DESCRIPTION
I made this for myself, since I couldn't get the makefile to work.
The problem ended being something unrelated, but since I made it I thought I'd make a PR.

```
cmake -Bbuild -GNinja -DCMAKE_INSTALL_PREFIX=~/.local/m908
cmake --build build
cmake --install build
```
Result
```
-- Install configuration: ""
-- Installing: ~/.local/m908/bin/mouse_m908
-- Installing: ~/.local/m908/etc/udev/rules.d/mouse_m908.rules
-- Installing: ~/.local/m908/share/man/mouse_m908.1
-- Installing: ~/.local/m908/share/doc/mouse_m908/README.md
-- Installing: ~/.local/m908/share/doc/mouse_m908/keymap.md
-- Installing: ~/.local/m908/share/doc/mouse_m908/examples
-- Installing: ~/.local/m908/share/doc/mouse_m908/examples/example.macro
-- Installing: ~/.local/m908/share/doc/mouse_m908/examples/example_m709.ini
-- Installing: ~/.local/m908/share/doc/mouse_m908/examples/example_m908.ini
-- Installing: ~/.local/m908/share/doc/mouse_m908/examples/example_m711.ini
-- Installing: ~/.local/m908/share/doc/mouse_m908/examples/example_generic.ini
-- Installing: ~/.local/m908/share/doc/mouse_m908/examples/example_m990chroma.ini
-- Installing: ~/.local/m908/share/doc/mouse_m908/examples/example_m715.ini
```
