### PR TITLE
fix: build on fedora:latest

### DIFF
--- a/include/rd_mouse_wireless.h
+++ b/include/rd_mouse_wireless.h
@@ -23,6 +23,7 @@
 #include <string>
 #include <map>
 #include <vector>
+#include <cstdint>
 
 /**
  * This class holds data that is shared between the wireless mice.

--- a/mouse_m908.spec
+++ b/mouse_m908.spec
@@ -12,7 +12,7 @@ Summary: Control Redragon gaming mice from Linux, BSD and Haiku
 
 License: GPL v3
 URL:     https://github.com/dokutan/mouse_m908
-BuildRequires: gcc-c++ libusb libusb-devel make
+BuildRequires: gcc-c++ libusb1 libusb1-devel make
 Requires: libusb
 ExclusiveArch: x86_64
 


### PR DESCRIPTION
Hello friend!

I was trying to build this in latest fedora and ran into some problems, here are the fixes:

1. libusb has been renamed to libusb1
2. It seems newer GCC detected a missing include for <cstdint>

Hope this is helpful.

Regards,

Alex