### PR TITLE
Ignore macro code ff ff 0

### DIFF
--- a/include/rd_mouse.cpp
+++ b/include/rd_mouse.cpp
@@ -425,6 +425,9 @@ int rd_mouse::_i_decode_macro( const std::vector< uint8_t >& macro_bytes, std::o
 			
 		}
 		
+		else if( macro_bytes[i] == 0xff && macro_bytes[i+1] == 0xff && macro_bytes[i+2] == 0x00 ){
+		}
+		
 		// padding (increment by one until a code appears)
 		else if( macro_bytes[i] == 0x00 ){
 			i++;


### PR DESCRIPTION
Fixes #79. I ran into the same issue on a new mouse, and when assigning a button to the macro, I didn't see any input (tested with `evtest`). I implemented the fix described to ignore it.